### PR TITLE
set resource limits of BC, DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog for Thoth's User API Service
+
+## [0.3.0] - 2018-Jun-12 - goern
+
+### Added
+
+Set resource limits of BuildConfig and Deployment to reasonable values, this will prevent unpredicted behavior on UpShift.

--- a/README.rst
+++ b/README.rst
@@ -5,5 +5,6 @@ This API is as a user-facing service, and part of `Thoth Core project <https://g
 
 It's main aim is to provide a management service that can be used directly by users for the `thoth-middeend` part. See `Thoth-core <https://github.com/thoth-station/core>`_ for more details.
 
-The service is built using OpenShift s2i. The configuration of s2i build is specified in the `.s2i/environment file <https://github.com/thoth-station/result-api/blob/master/.s2i/environment>`_. See also `s2i-python-container README <https://github.com/sclorg/s2i-python-container>`_ for more info. There is required Python 3.6 to run this application, the actual s2i build config is part of `Thoth-core OpenShift template <https://github.com/thoth-station/core/blob/master/openshift/template.yaml>`_.
+The service is built using OpenShift Source-to-Image. See also `s2i-python-container README <https://github.com/sclorg/s2i-python-container>`_ for more info.
 
+Python 3.6 is required to run this application.

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     description: This is Thoth User API BuildConfig, this template is meant to be used by Jenkins, but could also be used by humans...
     openshift.io/display-name: 'Thoth Core: User API BuildConfig'
-    version: 0.2.0
+    version: 0.3.0
     tags: poc,thoth,thoth-user-api,ai-stacks
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: This is Thoth User API BuildConfig, this template is meant to be used by Jenkins, but could also be used by humans...
@@ -22,6 +22,13 @@ objects:
     labels:
       app: thoth-core
   spec:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
     output:
       to:
         kind: ImageStreamTag

--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     description: This is Thoth Core - User API
     openshift.io/display-name: 'Thoth Core: User API'
-    version: 0.2.0
+    version: 0.3.0
     tags: poc,thoth,user-api,ai-stacks
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: This template defines resources needed to deploy Thoth Core Services as a Proof-of-Concept to OpenShift.
@@ -163,11 +163,11 @@ objects:
               protocol: TCP
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "125m"
+              memory: "256Mi"
+              cpu: "250m"
             limits:
               memory: "256Mi"
-              cpu: "500m"
+              cpu: "250m"
           readinessProbe:
             httpGet:
               path: '/readiness'

--- a/thoth_user_api/__init__.py
+++ b/thoth_user_api/__init__.py
@@ -1,4 +1,4 @@
 """Thoth User API."""
 
 __name__ = 'thoth-user-api'
-__version__ = '0.2.0'
+__version__ = '0.3.0'


### PR DESCRIPTION
Set resource limits of BuildConfig and Deployment to reasonable values, this will prevent unpredicted behavior on UpShift.