### PR TITLE
Avoid circular JSONs on error response

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -224,7 +224,7 @@ def post_advise_python(input: dict, recommendation_type: str, count: int = None,
         **project.to_dict(),
         count=parameters['count'],
         limit=parameters['limit'],
-        runtime_environment=parameters['application_stack']['runtime_environment']
+        runtime_environment=parameters['input']['runtime_environment']
     ))
 
     if not force:

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -492,12 +492,12 @@ def _do_run(parameters: dict, runner: typing.Callable, **runner_kwargs):
 
 
 def _do_get_image_metadata(image: str, registry_user: str = None, registry_password: str = None,
-                           verify_tls: bool = True) -> dict:
+                           verify_tls: bool = True) -> typing.Tuple[dict, int]:
     """Wrap function call with additional checks."""
     try:
         return get_image_metadata(
             image, registry_user=registry_user, registry_password=registry_password, verify_tls=verify_tls
-        )
+        ), 200
     except ImageManifestUnknownError as exc:
         status_code = 400
         error_str = str(exc)

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -200,13 +200,15 @@ def post_advise_python(input: dict, recommendation_type: str, count: int = None,
                        debug: bool = False, force: bool = False):
     """Compute results for the given package or package stack using adviser."""
     parameters = locals()
+    parameters['application_stack'] = parameters['input'].pop('application_stack')
+    parameters['runtime_environment'] = parameters['input'].pop('runtime_environment', None)
+    parameters.pop('input')
     force = parameters.pop('force', False)
-    parameters.pop('parameters', None)
 
     try:
         project = Project.from_strings(
-            parameters['input']['application_stack']['requirements'],
-            parameters['input']['application_stack'].get('requirements_lock')
+            parameters['application_stack']['requirements'],
+            parameters['application_stack'].get('requirements_lock')
         )
     except ThothPythonException as exc:
         return {'parameters': parameters, 'error': f'Invalid application stack supplied: {str(exc)}'}, 400
@@ -224,7 +226,7 @@ def post_advise_python(input: dict, recommendation_type: str, count: int = None,
         **project.to_dict(),
         count=parameters['count'],
         limit=parameters['limit'],
-        runtime_environment=parameters['input']['runtime_environment']
+        runtime_environment=parameters.get('runtime_environment')
     ))
 
     if not force:


### PR DESCRIPTION
Also do not log exceptions on user API - users can supply wrong stacks all the
time, causing the application to report errors unnecessary too often.