### PR TITLE
Explicitly state python type

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1290,6 +1290,7 @@ components:
               type: string
               description: Pod name where the analysis was done.
             python:
+              type: object
               required:
                 - api_version
                 - implementation_name


### PR DESCRIPTION
Otherwise swagger-codegen generates incorrect type in the generated Python
client Thamos.

Related: https://github.com/thoth-station/thamos/issues/193