### PR TITLE
use postgresql hostname from thoth configmap

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -221,7 +221,10 @@ objects:
                       name: thoth
                       key: sentry-dsn
                 - name: KNOWLEDGE_GRAPH_HOST
-                  value: postgresql
+                  valueFrom:
+                    configMapKeyRef:
+                      key: postgresql-host
+                      name: thoth
                 - name: KNOWLEDGE_GRAPH_PORT
                   value: "5432"
                 - name: KNOWLEDGE_GRAPH_SSL_DISABLED


### PR DESCRIPTION
use postgresql hostname from thoth configmap
depends-on: https://github.com/thoth-station/thoth-ops/pull/97
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>