### PR TITLE
Check if database schema is up2date in readiness probe

### DIFF
--- a/thoth/user_api/entrypoint.py
+++ b/thoth/user_api/entrypoint.py
@@ -28,6 +28,7 @@ from prometheus_flask_exporter import PrometheusMetrics
 from thoth.common import SafeJSONEncoder
 from thoth.common import init_logging
 from thoth.storages import SolverResultsStore
+from thoth.storages import GraphDatabase
 
 import thoth.user_api as thoth_user_api
 
@@ -90,6 +91,11 @@ def _healthiness():
 @metrics.do_not_track()
 def api_readiness():
     """Report readiness for OpenShift readiness probe."""
+    graph = GraphDatabase()
+    graph.connect()
+    if not graph.is_schema_up2date():
+        raise ValueError("Database schema is not up to date")
+
     return _healthiness()
 
 


### PR DESCRIPTION
## This Pull Request implements

We would like to make sure the database schema is up2date before starting the
User API service. This way we will prevent from rolling a new API release which
would have inconsistent schema.