### PR TITLE
Redirect to HTTPS instead of HTTP if configured so

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -244,6 +244,8 @@ objects:
                     secretKeyRef:
                       name: postgresql
                       key: database-name
+                - name: THOTH_API_HTTPS
+                  value: "1"
               ports:
                 - containerPort: 8080
                   protocol: TCP

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -48,6 +48,8 @@ _LOGGER.setLevel(logging.DEBUG if bool(int(os.getenv("THOTH_USER_API_DEBUG", 0))
 _LOGGER.info(f"This is User API v%s", __version__)
 _LOGGER.debug("DEBUG mode is enabled!")
 
+_THOTH_API_HTTPS = bool(int(os.getenv("THOTH_API_HTTPS", 1)))
+
 # Expose for uWSGI.
 app = connexion.FlaskApp(__name__, specification_dir=Configuration.SWAGGER_YAML_PATH, debug=True)
 
@@ -98,6 +100,8 @@ def before_request_callback():
 @app.route("/")
 def base_url():
     """Redirect to UI by default."""
+    # https://github.com/pallets/flask/issues/773
+    request.environ['wsgi.url_scheme'] = 'https' if _THOTH_API_HTTPS else 'http'
     return redirect("api/v1/ui")
 
 


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #609

## This Pull Request implements

If the THOTH_API_HTTPS environment variable is set to 1, the scheme used in
redirects is configured to https instead of http to force HTTPS connection.