### PR TITLE
Do not introduce fatal fail if database schema was removed

### DIFF
--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -34,6 +34,7 @@ from flask_cors import CORS
 from thoth.common import datetime2datetime_str
 from thoth.common import init_logging
 from thoth.storages import GraphDatabase
+from thoth.storages.exceptions import DatabaseNotInitialized
 from thoth.user_api import __version__
 from thoth.user_api.configuration import Configuration
 from thoth.user_api.configuration import init_jaeger_tracer
@@ -92,7 +93,13 @@ def before_request_callback():
     if method == "GET" and path == "/metrics":
         graph = GraphDatabase()
         graph.connect()
-        _API_GAUGE_METRIC.set(int(graph.is_schema_up2date()))
+        try:
+            _API_GAUGE_METRIC.set(int(graph.is_schema_up2date()))
+        except DatabaseNotInitialized as exc:
+            # This can happen if database is erased after the service has been started as we
+            # have passed readiness probe with this check.
+            _LOGGER.exception("Cannot determine database schema as database is not initialized: %s", str(exc))
+            _API_GAUGE_METRIC.set(0)
 
 
 @app.route("/")


### PR DESCRIPTION
## Related Issues and Dependencies

If schema is not present on the database side, we fail with internal errors. We
should report database schema error instead.