### PR TITLE
Track only user endpoints

### DIFF
--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -74,7 +74,15 @@ application = app.app
 Configuration.tracer = init_jaeger_tracer("user_api")
 
 # create metrics and manager
-metrics = PrometheusMetrics(application, group_by="endpoint")
+metrics = PrometheusMetrics(
+    application,
+    group_by="endpoint",
+    excluded_paths=[
+        "/liveness",
+        "/readiness",
+        "/api/v1/ui",
+        ]
+    )
 manager = Manager(application)
 
 # Needed for session.


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies
Total number of endpoints hit include also /readiness, /healthness, /swagger-ui, /openapi etc..

## This Pull Request implements
Removal of count of endpoints hits rather than user endpoints.
