### PR TITLE
fixed /PythonPackagesCountInfoResponse_count_type

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2068,7 +2068,7 @@ components:
         - count
       properties:
         count:
-          type: int
+          type: integer
           description: Total number of Python packages.
     PythonPackagesCountInfoResponseError:
       type: object


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies
swagger UI was misbehaving

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

n/a

## Description

just a typo ifxed