### PR TITLE
Provide is_s2i flag on user API

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -905,6 +905,13 @@ paths:
             for automated reporting when results are available.
           schema:
             type: string
+        - name: is_s2i
+          in: query
+          required: false
+          description: >
+            A flag marking the given request coming from an OpenShift's S2I (Source-to-Image) build.
+          schema:
+            type: boolean
         - name: debug
           in: query
           required: false

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -248,6 +248,7 @@ def post_advise_python(
     limit: int = None,
     limit_latest_versions: int = None,
     origin: str = None,
+    is_s2i: bool = None,
     debug: bool = False,
     force: bool = False,
 ):
@@ -294,6 +295,7 @@ def post_advise_python(
             limit_latest_versions=parameters["limit_latest_versions"],
             recommendation_type=recommendation_type,
             origin=origin,
+            is_s2i=is_s2i,
         )
     )
 


### PR DESCRIPTION
## Related Issues and Dependencies

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Propagation of `is_s2i` flag from thamos' autodiscovery so that we can link data stored in the database.

## Description

Related: https://github.com/thoth-station/storages/pull/1378 https://github.com/thoth-station/common/pull/580