### PR TITLE
Added nullables to Runtime Environment properties

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1566,14 +1566,17 @@ components:
         operating_system:
           type: object
           description: Operating system used.
+          nullable: true
         python_version:
           type: string
           example: "3.6"
           description: Python version on which the application runs on.
+          nullable: true
         cuda_version:
           type: string
           example: "9.0"
           description: Nvidia CUDA version which the application uses.
+          nullable: true
         name:
           type: string
           example: "fedora:29-prod"


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #735
…

## This introduces a breaking change

- [ ] Yes
- [*] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
This adds makes the Runtime Environment variables nullable. 
The properties set nullable are - 

- Python Version
- Cuda version
- Operating System name 
- Operating System version 