### PR TITLE
Add configuration variables for adviser workflow

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -323,6 +323,11 @@ def post_advise_python(
         except CacheMiss:
             pass
 
+    parameters["deployment_name"] = Configuration.THOTH_DEPLOYMENT_NAME
+    parameters["ceph_bucket_name"] = Configuration.THOTH_CEPH_BUCKET
+    parameters["ceph_bucket_prefix"] = Configuration.THOTH_CEPH_BUCKET_PREFIX
+    parameters["ceph_host"] = Configuration.THOTH_S3_ENDPOINT_URL
+
     response, status = _do_schedule(parameters, _OPENSHIFT.schedule_adviser, output=Configuration.THOTH_ADVISER_OUTPUT)
     if status == 202:
         adviser_cache.store_document_record(

--- a/thoth/user_api/configuration.py
+++ b/thoth/user_api/configuration.py
@@ -41,6 +41,10 @@ class Configuration:
     THOTH_MIDDLETIER_NAMESPACE = os.environ["THOTH_MIDDLETIER_NAMESPACE"]
     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
     THOTH_HOST = os.environ["THOTH_HOST"]
+    THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
+    THOTH_CEPH_BUCKET = os.environ["THOTH_CEPH_BUCKET"]
+    THOTH_CEPH_BUCKET_PREFIX = os.environ["THOTH_CEPH_BUCKET_PREFIX"]
+    THOTH_S3_ENDPOINT_URL = os.environ["THOTH_S3_ENDPOINT_URL"]
     # Give cache 3 hours by default.
     THOTH_CACHE_EXPIRATION = int(os.getenv("THOTH_CACHE_EXPIRATION", timedelta(hours=3).total_seconds()))
 


### PR DESCRIPTION
Depends-On: https://github.com/thoth-station/common/pull/706

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Generalize variables for adviser workflows to store on Ceph