### PR TITLE
Get status of an adviser run from a Workflow

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -52,6 +52,7 @@ from .exceptions import ImageError
 from .exceptions import ImageBadRequestError
 from .exceptions import ImageManifestUnknownError
 from .exceptions import ImageAuthenticationRequired
+from .exceptions import NotFoundException
 
 
 PAGINATION_SIZE = 100
@@ -351,7 +352,35 @@ def get_advise_python_log(analysis_id: str):
 
 def get_advise_python_status(analysis_id: str):
     """Get status of an adviser run."""
-    return _get_job_status(locals(), "adviser-", Configuration.THOTH_BACKEND_NAMESPACE)
+    status, code = _get_job_status(locals(), "adviser-", Configuration.THOTH_BACKEND_NAMESPACE)
+    if "error" in status:
+        wf_status = None
+        try:
+            wf_status = _OPENSHIFT.get_workflow_status(
+                name=analysis_id,
+                namespace=Configuration.THOTH_BACKEND_NAMESPACE
+            )
+
+            # the Job has not started (yet) but the Workflow has been submitted
+            # if the Workflow fails, the status will contain the finished
+            # time of the workflow
+            status["status"], code = {
+                "container": None,
+                "exit_code": None,
+                "finished_at": wf_status.get("finishedAt"),
+                "reason": None,
+                "started_at": wf_status.get("startedAt"),
+                "state": wf_status["phase"]
+            }, 200
+
+            status.pop("error")
+
+        except NotFoundException as exc:
+            # Handle this since the adviser run can still be scheduled
+            # with workload-operator instead, otherwise we could raise here
+            _LOGGER.error(status["error"])
+
+    return status, code
 
 
 def list_runtime_environments():
@@ -784,7 +813,7 @@ def _get_job_status(parameters: dict, name_prefix: str, namespace: str):
     except OpenShiftNotFound:
         return {"parameters": parameters, "error": f"Requested status for analysis {job_id!r} was not found"}, 404
 
-    return {"parameters": parameters, "status": status}
+    return {"parameters": parameters, "status": status}, 200
 
 
 def _do_schedule(parameters: dict, runner: typing.Callable, **runner_kwargs):

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -370,7 +370,7 @@ def get_advise_python_status(analysis_id: str):
                 "finished_at": wf_status.get("finishedAt"),
                 "reason": None,
                 "started_at": wf_status.get("startedAt"),
-                "state": wf_status["phase"]
+                "state": wf_status.get("phase", "Pending")
             }, 200
 
             status.pop("error")


### PR DESCRIPTION
Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   thoth/user_api/api_v1.py

## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/common/pull/713

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Attempt to get an adviser run status from a Workflow if there is no Job (yet) to get the status from.