### PR TITLE
Add parameter to re run adviser for unsolved dependencies

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -257,6 +257,7 @@ def post_advise_python(
     github_check_run_id: typing.Optional[int] = None,
     github_installation_id: typing.Optional[int] = None,
     github_base_repo_url: typing.Optional[str] = None,
+    re_run_adviser_id: typing.Optional[str] = None,
 ):
     """Compute results for the given package or package stack using adviser."""
     parameters = locals()


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/common/pull/727

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add parameter to keep track of adviser run that are re running after all unsolved packages have been solved. The parameter shows the initial adviser run where the unsolved packages have been identified.