### PR TITLE
introduced a service version string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 .idea
 .vscode/
+.thoth_last_analysis_id

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -31,8 +31,11 @@ from flask_script import Manager
 from prometheus_flask_exporter import PrometheusMetrics
 from flask_cors import CORS
 
+
+from thoth.common import __version__ as __common__version__
 from thoth.common import datetime2datetime_str
 from thoth.common import init_logging
+from thoth.storages import __version__ as __storages__version__
 from thoth.storages import GraphDatabase
 from thoth.storages.exceptions import DatabaseNotInitialized
 from thoth.user_api import __version__
@@ -46,7 +49,9 @@ init_logging(logging_env_var_start="THOTH_USER_API_LOG_")
 _LOGGER = logging.getLogger("thoth.user_api")
 _LOGGER.setLevel(logging.DEBUG if bool(int(os.getenv("THOTH_USER_API_DEBUG", 0))) else logging.INFO)
 
-_LOGGER.info(f"This is User API v%s", __version__)
+__service_versin__ = f"{__version__}+storage.{__storages__version__}.common.{__common__version__}"
+
+_LOGGER.info(f"This is User API v%s", __service_version__)
 _LOGGER.debug("DEBUG mode is enabled!")
 
 _THOTH_API_HTTPS = bool(int(os.getenv("THOTH_API_HTTPS", 1)))
@@ -90,7 +95,7 @@ manager = Manager(application)
 application.secret_key = Configuration.APP_SECRET_KEY
 
 # static information as metric
-metrics.info("user_api_info", "User API info", version=__version__)
+metrics.info("user_api_info", "User API info", version=__service_version__)
 _API_GAUGE_METRIC = metrics.info("user_api_schema_up2date", "User API schema up2date")
 
 
@@ -151,7 +156,7 @@ def api_v1():
 
 
 def _healthiness():
-    return jsonify({"status": "ready", "version": __version__}), 200, {"ContentType": "application/json"}
+    return jsonify({"status": "ready", "version": __service_version__}), 200, {"ContentType": "application/json"}
 
 
 @app.route("/readiness")

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -49,7 +49,7 @@ init_logging(logging_env_var_start="THOTH_USER_API_LOG_")
 _LOGGER = logging.getLogger("thoth.user_api")
 _LOGGER.setLevel(logging.DEBUG if bool(int(os.getenv("THOTH_USER_API_DEBUG", 0))) else logging.INFO)
 
-__service_versin__ = f"{__version__}+storage.{__storages__version__}.common.{__common__version__}"
+__service_version__ = f"{__version__}+storage.{__storages__version__}.common.{__common__version__}"
 
 _LOGGER.info(f"This is User API v%s", __service_version__)
 _LOGGER.debug("DEBUG mode is enabled!")


### PR DESCRIPTION
introduced a service version string that contains the depending module's versions

Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies

n/a

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

A service version string.

## Description

The version string used in metrics, health and log now contains the versions of dependent modules like thoth-storages too. The version returns as X-Thoth-Version http header does not include these additional details.
