### PR TITLE
Added a route to receive webhook

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2244,12 +2244,7 @@ components:
           description: Parameters echoed back to user for debugging.
     KebechetWebhookInput:
       type: object
-      required:
-        - webhook_payload
-      properties:
-        webhook_payload:
-          type: object
-          description: Webhook payload from Github event.
+      description: Webhook payload from Github event.
     QebHwtThamosAdviseInput:
       type: object
       required:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1076,6 +1076,29 @@ paths:
         "501":
           description: Functionality not supported
 
+  /kebechet-webhook:
+    post:
+      tags: [Kebechet]
+      x-openapi-router-controller: thoth.user_api.api_v1
+      operationId: schedule_kebechet_webhook
+      summary: Schedule kebechet instance from webhook
+      requestBody:
+        required: true
+        description: Body of a git service webhook
+        content:
+          application/json:
+            schema:
+              x-body-name: body
+              $ref: "#/components/schemas/KebechetWebhookInput"
+              additionalProperties: true
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: Invalid
+        "501":
+          description: Functionality not supported
+
   /qeb-hwt:
     post:
       tags: [GitHub]
@@ -2214,6 +2237,14 @@ components:
         parameters:
           type: object
           description: Parameters echoed back to user for debugging.
+    KebechetWebhookInput:
+      type: object
+      required:
+        - webhook_payload
+      properties:
+        webhook_payload:
+          type: object
+          description: Webhook payload from Github event.
     QebHwtThamosAdviseInput:
       type: object
       required:

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -704,9 +704,13 @@ def schedule_kebechet(body: dict):
 
 def schedule_kebechet_webhook(body: typing.Dict[str, typing.Any]):
     """Schedule Kebechet on Openshift."""
-    parsed_payload = json.dumps(body['webhook_payload'])
-    body['webhook_payload'] = parsed_payload
-    return _do_schedule(body, _OPENSHIFT.schedule_kebechet_workflow)
+    try:
+        parsed_payload = json.dumps(body)
+    except err:
+        return {"error": "This webhook is not supported"}, 501
+    payload = {}
+    payload['webhook_payload'] = parsed_payload
+    return _do_schedule(payload, _OPENSHIFT.schedule_kebechet_workflow)
 
 
 def schedule_thamos_advise(

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -702,6 +702,13 @@ def schedule_kebechet(body: dict):
     return _do_schedule(parameters, _OPENSHIFT.schedule_kebechet_run_url)
 
 
+def schedule_kebechet_webhook(body: typing.Dict[str, typing.Any]):
+    """Schedule Kebechet on Openshift."""
+    parsed_payload = json.dumps(body['webhook_payload'])
+    body['webhook_payload'] = parsed_payload
+    return _do_schedule(body, _OPENSHIFT.schedule_kebechet_workflow)
+
+
 def schedule_thamos_advise(
     input: typing.Dict[str, typing.Any],
 ):


### PR DESCRIPTION
## Related Issues and Dependencies
Related Issue - #854 
Dependent on https://github.com/thoth-station/common/pull/780 and https://github.com/thoth-station/kebechet/pull/361

## This Pull Request implements

Route to receive webhook's. 

## Description
This route takes in a webhook in form - 
```
{
  "webhook_payload":  <json webhook>
}
```
Example job initiated using the route to test the whole workflow - [link](http://argo-ui-thoth-test-core.cloud.paas.psi.redhat.com/workflows/thoth-test-core/kebechet-job-4f2b0ded?tab=workflow&nodeId=kebechet-job-4f2b0ded-3043601693)