### PR TITLE
condition for argo check before workflow status check

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -361,7 +361,7 @@ def get_advise_python_log(analysis_id: str):
 def get_advise_python_status(analysis_id: str):
     """Get status of an adviser run."""
     status, code = _get_job_status(locals(), "adviser-", Configuration.THOTH_BACKEND_NAMESPACE)
-    if code == 404:
+    if code == 404 and os.getenv("THOTH_USE_ARGO") == "1":
         wf_status = None
         try:
             wf_status = _OPENSHIFT.get_workflow_status(


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies
Fixes: #863 

## This introduces a breaking change

- [ ] Yes
- [ x] No

## This Pull Request implements

Just a check on THOTH_USE_ARGO.

## Description

This check will help if running legacy system workload-operator and argo is not present. If job is not found it would respond with the status then going into argo error.