### PR TITLE
fix key error state

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -814,7 +814,7 @@ def _get_document(adapter_class, analysis_id: str, name_prefix: str = None, name
         if namespace:
             try:
                 status = _OPENSHIFT.get_job_status_report(analysis_id, namespace=namespace)
-                if status["state"] == "running" or (status["state"] == "terminated" and status["exit_code"] == 0):
+                if status["pods"][0]["state"] == "running" or (status["pods"][0]["state"] == "terminated" and status["pods"][0]["exit_code"] == 0):
                     # In case we hit terminated and exit code equal to 0, the analysis has just finished and
                     # before this call (document retrieval was unsuccessful, pod finished and we asked later
                     # for status). To fix this time-dependent issue, let's user ask again. Do not do pod status

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -814,7 +814,8 @@ def _get_document(adapter_class, analysis_id: str, name_prefix: str = None, name
         if namespace:
             try:
                 status = _OPENSHIFT.get_job_status_report(analysis_id, namespace=namespace)
-                if status["pods"][0]["state"] == "running" or (status["pods"][0]["state"] == "terminated" and status["pods"][0]["exit_code"] == 0):
+                if status["pods"][0]["state"] == "running" or \
+                        (status["pods"][0]["state"] == "terminated" and status["pods"][0]["exit_code"] == 0):
                     # In case we hit terminated and exit code equal to 0, the analysis has just finished and
                     # before this call (document retrieval was unsuccessful, pod finished and we asked later
                     # for status). To fix this time-dependent issue, let's user ask again. Do not do pod status


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/user-api/issues/871

## This introduces a breaking change

- [ ] Yes
- [ X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

## Description

I looked at [sentry](https://sentry.io/organizations/thoth-station/issues/1637271929/?project=1298083&referrer=github_integration) and observed the `status` object. The contents of `status` object as below:
```json
{
  "completions": 1, 
  "failed": 1, 
  "pods": [
               {
                 "container": "8762e63788ccdc66958a42c45a61984a512ba1d9f1c2705fdb4086760e1b713c", 
                 "exit_code": 1, 
                 "finished_at": "2020-04-29T12:30:27Z", 
                 "reason": "Error", 
                 "started_at": "2020-04-29T12:30:27Z", 
                 "state": "terminated"
               }
  ], 
  "started_at": "2020-04-29T12:30:03Z"
}
```
And, from it, we see that there is no `state` key indeed. We have it inside `pods`. For now, I chose just the first pod `status["pods"][0]`, WDYT @fridex ?