### PR TITLE
Ignore kebechet run on push event on bot branch

### DIFF
--- a/thoth/user_api/payload_filter.py
+++ b/thoth/user_api/payload_filter.py
@@ -32,6 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 _SUPPORTED_ACTIONS = ["opened", "edited"]
 _EVENT_TYPES = ["issues", "pull_request", "installation"]
 _DEPRECATED_EVENTS = ["integration_installation", "integration_installation_repositories"]
+_BOT_BRANCH = "refs/heads/kebechet-"
 
 
 class PayloadProcess:
@@ -64,6 +65,14 @@ class PayloadProcess:
                     return None
                 elif payload.get("action") == "removed":
                     self._remove_event(payload.get("repositories_removed"))
+                    return None
+            if event == "push":
+                # Do not re-run kebechet if push event is on bot branch. 
+                ref = payload.get("ref")
+                if ref.startswith(_BOT_BRANCH):
+                    _LOGGER.info(
+                        f"For event type - {event}, we ignore bot branch."
+                    )
                     return None
             if event in _EVENT_TYPES:
                 # We ignore issues, PR actions like reopened, closed.

--- a/thoth/user_api/payload_filter.py
+++ b/thoth/user_api/payload_filter.py
@@ -67,7 +67,7 @@ class PayloadProcess:
                     self._remove_event(payload.get("repositories_removed"))
                     return None
             if event == "push":
-                # Do not re-run kebechet if push event is on bot branch. 
+                # Do not re-run kebechet if push event is on bot branch.
                 ref = payload.get("ref")
                 if ref.startswith(_BOT_BRANCH):
                     _LOGGER.info(

--- a/thoth/user_api/payload_filter.py
+++ b/thoth/user_api/payload_filter.py
@@ -69,7 +69,7 @@ class PayloadProcess:
             if event == "push":
                 # Do not re-run kebechet if push event is on bot branch.
                 ref = payload.get("ref")
-                if ref.startswith(_BOT_BRANCH):
+                if ref is None or ref.startswith(_BOT_BRANCH):
                     _LOGGER.info(
                         f"For event type - {event}, we ignore bot branch."
                     )


### PR DESCRIPTION
## Related Issues and Dependencies
Kebechet shouldn't run on a push event on its own branch, hence going on an endless loop  - 
https://github.com/thoth-station/srcops-testing/pull/231 creating 800+ comments and rebases :fearful: 
