### PR TITLE
User-API response requires string not enum

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -323,7 +323,8 @@ def post_advise_python(
         except CacheMiss:
             pass
 
-    parameters["source_type"] = getattr(ThothAdviserIntegrationEnum, source_type.upper()) if source_type else None
+    # Enum type is checked on thoth-common side to avoid serialization issue in user-api side when providing response
+    parameters["source_type"] = source_type if source_type else None
     response, status = _do_schedule(parameters, _OPENSHIFT.schedule_adviser, output=Configuration.THOTH_ADVISER_OUTPUT)
     if status == 202:
         adviser_cache.store_document_record(

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -324,7 +324,7 @@ def post_advise_python(
             pass
 
     # Enum type is checked on thoth-common side to avoid serialization issue in user-api side when providing response
-    parameters["source_type"] = source_type if source_type else None
+    parameters["source_type"] = source_type.upper() if source_type else None
     response, status = _do_schedule(parameters, _OPENSHIFT.schedule_adviser, output=Configuration.THOTH_ADVISER_OUTPUT)
     if status == 202:
         adviser_cache.store_document_record(


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/user-api/issues/908

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

make sure the response given by User-API does not contain Enum types.