### PR TITLE
Invalid credentials are a special type of image error

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -874,6 +874,9 @@ def _do_get_image_metadata(
     except ImageBadRequestError as exc:
         status_code = 400
         error_str = str(exc)
+    except ImageInvalidCredentials as exc:
+        status_code = 403
+        error_str = str(exc)
     except ImageManifestUnknownError as exc:
         status_code = 400
         error_str = str(exc)
@@ -882,9 +885,6 @@ def _do_get_image_metadata(
         error_str = str(exc)
     except ImageError as exc:
         status_code = 400
-        error_str = str(exc)
-    except ImageInvalidCredentials as exc:
-        status_code = 403
         error_str = str(exc)
 
     return {"error": error_str, "parameters": locals()}, status_code


### PR DESCRIPTION
Based on exception hierarchy, the invalid credentials error will never be
handled if exception is caught after image error.

