### PR TITLE
Do not propagate message topic in responses

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -478,7 +478,10 @@ def get_python_platform() -> typing.List[str]:
     return GRAPH.get_python_package_version_platform_all()
 
 
-def list_python_package_versions(name: str, page: int = 0,) -> typing.Tuple[typing.Dict[str, typing.Any], int]:
+def list_python_package_versions(
+    name: str,
+    page: int = 0,
+) -> typing.Tuple[typing.Dict[str, typing.Any], int]:
     """Get information about versions available."""
     parameters = locals()
 
@@ -486,7 +489,10 @@ def list_python_package_versions(name: str, page: int = 0,) -> typing.Tuple[typi
 
     try:
         query_result = GRAPH.get_python_package_versions_all(
-            package_name=name, distinct=True, is_missing=False, start_offset=page,
+            package_name=name,
+            distinct=True,
+            is_missing=False,
+            start_offset=page,
         )
     except NotFoundError:
         return {"error": f"Package {name!r} not found", "parameters": parameters}, 404
@@ -509,7 +515,10 @@ def get_python_package_dependencies(
     from .openapi_server import GRAPH
 
     if (os_name is None and os_version is not None) or (os_name is not None and os_version is None):
-        return {"error": "Operating system is not fully specified", "parameters": parameters,}, 400
+        return {
+            "error": "Operating system is not fully specified",
+            "parameters": parameters,
+        }, 400
 
     if marker_evaluation_result is not None and (os_name is None or os_version is None or python_version is None):
         return (
@@ -546,7 +555,12 @@ def get_python_package_dependencies(
     for extra, entries in query_result.items():
         for entry in entries:
             result.append(
-                {"name": entry[0], "version": entry[1], "extra": extra, "environment_marker": None,}
+                {
+                    "name": entry[0],
+                    "version": entry[1],
+                    "extra": extra,
+                    "environment_marker": None,
+                }
             )
 
             if os_name is not None and os_version is not None and python_version is not None:
@@ -740,7 +754,9 @@ def schedule_kebechet_webhook(body: typing.Dict[str, typing.Any]):
     return _send_schedule_message(payload, KebechetTriggerMessage)
 
 
-def schedule_qebhwt_advise(input: typing.Dict[str, typing.Any],):
+def schedule_qebhwt_advise(
+    input: typing.Dict[str, typing.Any],
+):
     """Schedule Thamos Advise for GitHub App."""
     input["host"] = Configuration.THOTH_HOST
     input["job_id"] = _OPENSHIFT.generate_id("qeb-hwt")
@@ -767,7 +783,10 @@ def get_python_package_versions_count(
         }
     except NotFoundError:
         return (
-            {"error": "Not able to retrieve the number with the given inputs", "parameters": parameters,},
+            {
+                "error": "Not able to retrieve the number with the given inputs",
+                "parameters": parameters,
+            },
             404,
         )
 

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -882,7 +882,6 @@ def _send_schedule_message(message_contents: dict, message_type: MessageBase):
     if "job_id" in message_contents:
         return (
             {
-                "message_topic": message_type().topic_name,
                 "analysis_id": message_contents["job_id"],
                 "parameters": message_contents,
                 "cached": False,

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -83,7 +83,14 @@ application = app.app
 
 # create metrics and manager
 metrics = PrometheusMetrics(
-    application, group_by="endpoint", excluded_paths=["/liveness", "/readiness", "/api/v1/ui", "/api/v1/openapi",],
+    application,
+    group_by="endpoint",
+    excluded_paths=[
+        "/liveness",
+        "/readiness",
+        "/api/v1/ui",
+        "/api/v1/openapi",
+    ],
 )
 manager = Manager(application)
 


### PR DESCRIPTION
## Related Issues and Dependencies

We should not expose message topics to the outside world. The fact we use messaging to serve requests is an implementation detail and user's of Thoth should not have capability to rely on topic name in responses. The message topic is also not present in response schema.

## This introduces a breaking change

- [x] No
