### PR TITLE
Remove legacy build analysis result endpoints

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1145,62 +1145,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/BuildAnalysisResponseError"
 
-  /buildlog-analyze:
-    get:
-      tags: ["Buildlogs"]
-      x-openapi-router-controller: thoth.user_api.api_v1
-      operationId: list_buildlog_analyze
-      summary: Retrieve a list of document ids for build analyzer results.
-      parameters:
-        - $ref: "#/components/parameters/page"
-      responses:
-        "200":
-          description: A list of build analyzer results available.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalysisListingResponse"
-        "400":
-          description: On invalid request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalysisResponseError"
-
-  /buildlog-analyze/{analysis_id}:
-    get:
-      tags: ["Buildlogs"]
-      x-openapi-router-controller: thoth.user_api.api_v1
-      operationId: get_buildlog_analyze
-      summary: Retrieve a build analyzer result.
-      parameters:
-        - $ref: "#/components/parameters/analysis_id"
-      responses:
-        "200":
-          description: Build Analyzer result retrieved.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalysisResultResponse"
-        "202":
-          description: Results are not ready yet.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalysisStatusResponse"
-        "400":
-          description: On invalid request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalysisResponseError"
-        "404":
-          description: The given document does not exist.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalysisResponseError"
-
   /python/platform:
     get:
       tags: [PythonPackages]

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -30,7 +30,6 @@ from thoth.storages import AdvisersResultsStore
 from thoth.storages import AnalysisResultsStore
 from thoth.storages import BuildLogsStore
 from thoth.storages import BuildLogsAnalysesCacheStore
-from thoth.storages import BuildLogsAnalysisResultsStore
 from thoth.storages import ProvenanceResultsStore
 from thoth.storages import AnalysesCacheStore
 from thoth.storages import AdvisersCacheStore
@@ -818,21 +817,6 @@ def _store_build_log(
     adapter.connect()
     document_id = adapter.store_document(build_log)
     return document_id, buildlog_analysis_id
-
-
-def list_buildlog_analyze(page: int = 0):
-    """Retrieve list of build log analysis result."""
-    return _do_listing(BuildLogsAnalysisResultsStore, page)
-
-
-def get_buildlog_analyze(analysis_id: str):
-    """Retrieve build log analysis result."""
-    return _get_document(
-        BuildLogsAnalysisResultsStore,
-        analysis_id,
-        name_prefix="build-analyze-",
-        namespace=Configuration.THOTH_BACKEND_NAMESPACE,
-    )
 
 
 def get_buildlog(document_id: str):


### PR DESCRIPTION
## Related Issues and Dependencies

This is causing issues in deployment as the used adapter is no longer present. Moreover, we should not expose these endpoints directlyy to users as they can keep sensitive data.

## This introduces a breaking change

- [x] No
