### PR TITLE
Use confluent Kafka producer

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -50,6 +50,7 @@ from thoth.messaging import BuildAnalysisTriggerMessage
 from thoth.messaging import PackageExtractTriggerMessage
 from thoth.messaging import ProvenanceCheckerTriggerMessage
 from thoth.messaging import QebHwtTriggerMessage
+from thoth.messaging.config import kafka_config_from_env
 
 from confluent_kafka import Producer
 
@@ -68,18 +69,7 @@ PAGINATION_SIZE = 100
 _LOGGER = logging.getLogger(__name__)
 _OPENSHIFT = OpenShift()
 
-config_topic = MessageBase()
-
-if config_topic.protocol == "SSL":
-    p = Producer(
-        {
-            "bootstrap.servers": config_topic.bootstrap_server,
-            "ssl.ca.location": Configuration.KAFKA_CAFILE,
-            "security.protocol": config_topic.protocol,
-        }
-    )
-else:
-    p = Producer({"bootstrap.servers": config_topic.bootstrap_server})
+p = Producer(kafka_config_from_env())
 
 
 def _compute_digest_params(parameters: dict):


### PR DESCRIPTION
## Related Issues and Dependencies

Looks like deployment configuration needs to be also adjusted.

```
Failed to add operation for POST /api/v1/image/metadata
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/resolver.py", line 61, in resolve_function_from_operation_id
    return self.function_resolver(operation_id)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/utils.py", line 111, in get_function_from_name
    module = importlib.import_module(module_name)
  File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/app-root/src/thoth/user_api/api_v1.py", line 73, in <module>
    if config_topic.protocol == "SSL":
AttributeError: 'MessageBase' object has no attribute 'protocol'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/apis/abstract.py", line 209, in add_paths
    self.add_operation(path, method)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/apis/abstract.py", line 162, in add_operation
    operation = make_operation(
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/operations/__init__.py", line 8, in make_operation
    return spec.operation_cls.from_spec(spec, *args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/operations/openapi.py", line 128, in from_spec
    return cls(
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/operations/openapi.py", line 75, in __init__
    super(OpenAPIOperation, self).__init__(
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/operations/abstract.py", line 96, in __init__
    self._resolution = resolver.resolve(self)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/resolver.py", line 40, in resolve
    return Resolution(self.resolve_function_from_operation_id(operation_id), operation_id)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/resolver.py", line 66, in resolve_function_from_operation_id
    raise ResolverError(str(e), sys.exc_info())
connexion.exceptions.ResolverError: <ResolverError: 'MessageBase' object has no attribute 'protocol'>
```

## This introduces a breaking change

- [x] No
