### PR TITLE
Allow nullable responses in post-build endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1704,10 +1704,10 @@ components:
         base_image_analysis:
           type: object
           description: Response for a submitted analysis.
+          nullable: true
           properties:
             analysis_id:
               type: string
-              nullable: true
               description: >
                 An id of submitted analysis for checking its status and its results.
             cached:
@@ -1717,10 +1717,10 @@ components:
         output_image_analysis:
           type: object
           description: Response for a submitted analysis.
+          nullable: true
           properties:
             analysis_id:
               type: string
-              nullable: true
               description: >
                 An id of submitted analysis for checking its status and its results.
             cached:
@@ -1730,12 +1730,12 @@ components:
         buildlog_analysis:
           type: object
           description: Response for a submitted analysis.
+          nullable: true
           properties:
             analysis_id:
               type: string
               description: >
                 An id of submitted analysis for checking its status and its results.
-              nullable: true
             cached:
               type: boolean
               description: >
@@ -1743,10 +1743,6 @@ components:
         buildlog_document_id:
           type: string
           description: Document identifier for the stored build log.
-      required:
-        - base_image_analysis
-        - output_image_analysis
-        - buildlog_analysis
     AnalysisResponse:
       type: object
       description: Response for a submitted analysis.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1707,6 +1707,7 @@ components:
           properties:
             analysis_id:
               type: string
+              nullable: true
               description: >
                 An id of submitted analysis for checking its status and its results.
             cached:
@@ -1719,6 +1720,7 @@ components:
           properties:
             analysis_id:
               type: string
+              nullable: true
               description: >
                 An id of submitted analysis for checking its status and its results.
             cached:
@@ -1733,6 +1735,7 @@ components:
               type: string
               description: >
                 An id of submitted analysis for checking its status and its results.
+              nullable: true
             cached:
               type: boolean
               description: >


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thamos/pull/695

```
Traceback (most recent call last):
  File "app.py", line 343, in _submitter
    _do_analyze_build(
  File "app.py", line 216, in _do_analyze_build
    analysis_response = build_analysis(
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/lib.py", line 102, in wrapper
    result = func(api_client, *args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/lib.py", line 758, in build_analysis
    response = api_instance.post_build(**params)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/thoth/build_analysis_api.py", line 63, in post_build
    (data) = self.post_build_with_http_info(body, **kwargs)  # noqa: E501
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/thoth/build_analysis_api.py", line 187, in post_build_with_http_info
    return self.api_client.call_api(
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 343, in call_api
    return self.__call_api(
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 174, in __call_api
    return_data = self.deserialize(response_data, response_type)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 247, in deserialize
    return self.__deserialize(data, response_type)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 286, in __deserialize
    return self.__deserialize_model(data, klass)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/api_client.py", line 691, in __deserialize_model
    instance = klass(**kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/models/build_analysis_response.py", line 59, in __init__
    self.base_image_analysis = base_image_analysis
  File "/opt/app-root/lib64/python3.8/site-packages/thamos/swagger_client/models/build_analysis_response.py", line 84, in base_image_analysis
    raise ValueError(
ValueError: Invalid value for `base_image_analysis`, must not be `None`
```

## This introduces a breaking change

- [x] No