### PR TITLE
Standardize metric for schema check

### DIFF
--- a/thoth/user_api/configuration.py
+++ b/thoth/user_api/configuration.py
@@ -32,6 +32,7 @@ class Configuration:
     SKOPEO_BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "bin", "skopeo")
     THOTH_MIDDLETIER_NAMESPACE = os.environ["THOTH_MIDDLETIER_NAMESPACE"]
     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
+    THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
     THOTH_HOST = os.environ["THOTH_HOST"]
     # Give cache 3 hours by default.
     THOTH_CACHE_EXPIRATION = int(os.getenv("THOTH_CACHE_EXPIRATION", timedelta(hours=3).total_seconds()))

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -126,6 +126,7 @@ schema_revision_metric = metrics.info(
     "Thoth database schema revision from script",
     component="user-api",  # label
     revision=GRAPH.get_script_alembic_version_head(),  # label
+    env=Configuration.THOTH_DEPLOYMENT_NAME
 )
 
 

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -126,7 +126,7 @@ schema_revision_metric = metrics.info(
     "Thoth database schema revision from script",
     component="user-api",  # label
     revision=GRAPH.get_script_alembic_version_head(),  # label
-    env=Configuration.THOTH_DEPLOYMENT_NAME
+    env=Configuration.THOTH_DEPLOYMENT_NAME,
 )
 
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/metrics-exporter/issues/529
Related-to: https://github.com/thoth-station/metrics-exporter/pull/577


Standardize metric for schema check introducing filter by deployment name, so that metrics-exporter can handle correct metrics.