### PR TITLE
Report an error if the given S2I container image analysis was not done

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -175,6 +175,15 @@ def list_s2i_python() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
             thoth_s2i_image_name, thoth_s2i_image_version, is_external=False
         )
 
+        if not analyses:
+            _LOGGER.error(
+                "Thoth s2i image %r in version %r was not analyzed, please schedule container image "
+                "analyses to make it available to users",
+                thoth_s2i_image_name,
+                thoth_s2i_image_version,
+            )
+            continue
+
         entries.append(
             {
                 "thoth_s2i_image_name": thoth_s2i_image_name,


### PR DESCRIPTION
## Related Issues and Dependencies

If running an older deployment, we might not have all the S2I Thoth container image analyzed. Let's report this fact to reporting systems so users can start consuming Thoth s2i.

## This introduces a breaking change

- [x] No
