### PR TITLE
Remove endpoint exposing number of Python packages

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1011,62 +1011,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/PythonPackageDependenciesError"
 
-  /python/packages/count:
-    get:
-      tags: [PythonPackages]
-      x-openapi-router-controller: thoth.user_api.api_v1
-      operationId: get_python_package_versions_count
-      summary: >
-        Retrieve information from the Knowledge Graph with regards
-        to total number of Python packages.
-      parameters:
-        - name: name
-          in: query
-          required: false
-          description: Name of the Python Package.
-          schema:
-            type: string
-            nullable: true
-            default: null
-            example: "tensorflow"
-        - name: version
-          in: query
-          required: false
-          description: Version of the Python Package.
-          schema:
-            type: string
-            nullable: true
-            default: null
-            example: "2.0.0"
-        - name: index
-          in: query
-          required: false
-          description: Index url of the Python Package.
-          schema:
-            type: string
-            nullable: true
-            default: null
-            example: "https://pypi.org/simple"
-      responses:
-        "200":
-          description: The number of Python packages in Thoth Knowledge Graph.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PythonPackagesCountInfoResponse"
-        "400":
-          description: On invalid request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PythonPackagesCountInfoResponseError"
-        "404":
-          description: The given record does not exist.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PythonPackagesCountInfoResponseError"
-
   /python/package/versions:
     get:
       tags: [PythonPackages]
@@ -1851,26 +1795,6 @@ components:
           type: string
           description: Analyzer logs printed to stdout/stderr as a plain text.
           nullable: true
-        parameters:
-          type: object
-          description: Parameters echoed back to user for debugging.
-    PythonPackagesCountInfoResponse:
-      type: object
-      required:
-        - count
-      properties:
-        count:
-          type: integer
-          description: Total number of Python packages.
-    PythonPackagesCountInfoResponseError:
-      type: object
-      required:
-        - error
-        - parameters
-      properties:
-        error:
-          type: string
-          description: Error information for user.
         parameters:
           type: object
           description: Parameters echoed back to user for debugging.

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -816,29 +816,6 @@ def list_buildlogs(page: int = 0):
     return _do_listing(BuildLogsStore, page)
 
 
-def get_python_package_versions_count(
-    name: typing.Optional[str] = None, version: typing.Optional[str] = None, index: typing.Optional[str] = None
-):
-    """Retrieve number of Python package versions in Thoth Knowledge Graph."""
-    parameters = locals()
-    from .openapi_server import GRAPH
-
-    try:
-        return {
-            "count": GRAPH.get_python_package_versions_count_all(
-                package_name=name, package_version=version, index_url=index
-            )
-        }
-    except NotFoundError:
-        return (
-            {
-                "error": "Not able to retrieve the number with the given inputs",
-                "parameters": parameters,
-            },
-            404,
-        )
-
-
 def get_package_metadata(name: str, version: str, index: str):
     """Retrieve metadata for the given package version."""
     parameters = locals()


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

I'm not sure if we want to have this endpoint available. This information is available via metrics and I think there is no value-added for users who consume data via user-api endpoints.
