### PR TITLE
Remove optional tag from required items listing

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1439,7 +1439,6 @@ components:
             description: Digests of image layesrs.
       required:
         - name
-        - tag
         - digest
         - repo_tags
         - created


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes:

```
'tag' is a required property
```

## This introduces a breaking change

- [x] No
