### PR TITLE
protect fields for post provenance and advise

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -271,6 +271,12 @@ paths:
             default: false
           description: >
             Do not use cached results, always run provenance checks.
+        - name: token
+          in: query
+          required: false
+          schema:
+            type: string
+          description: API token for sending priviledged requests.
       responses:
         "202":
           description: The provided files will be checked for provenance.
@@ -627,6 +633,12 @@ paths:
                 required: false
             additionalProperties: true
           description: Dict containing kebechet specific metadata for justification.
+        - name: token
+          in: query
+          required: false
+          schema:
+            type: string
+          description: API token for sending priviledged requests.
       responses:
         "202":
           description: The adviser is scheduled.

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -196,7 +196,7 @@ def list_s2i_python() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
     return {"s2i": entries}
 
 
-def list_container_images(page: int = 0) -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
+def list_container_images(page: int = 0) -> typing.Dict[str, typing.Any]:
     """List registered container images."""
     from .openapi_server import GRAPH
 

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -245,7 +245,7 @@ def post_provenance_python(
     force: bool = False,
     origin: str = None,
     # Must be set to set protected fields
-    internal_secret: typing.Optional[str] = None,
+    token: typing.Optional[str] = None,
     # Protected fields
     kebechet_metadata: typing.Optional[typing.Dict[str, typing.Any]] = None,
     justification: typing.Optional[typing.List[typing.Dict[str, typing.Any]]] = None,
@@ -255,10 +255,11 @@ def post_provenance_python(
     protected_fields = ["origin"]
     parameters = locals()
 
-    if Configuration.INTERNAL_SECRET == internal_secret:
+    if Configuration.API_TOKEN == token:
         for k in protected_fields:
             if parameters[k] is not None:
-                raise PermissionError("Attempted to set protected field without proper permissions.")
+                response = {"error": "Attempted to set protected field without proper permissions."}
+                return response, 401
 
     from .openapi_server import GRAPH
 
@@ -337,7 +338,7 @@ def post_advise_python(
     dev: bool = False,
     origin: typing.Optional[str] = None,
     # Must be set to set protected fields
-    internal_secret: typing.Optional[str] = None,
+    token: typing.Optional[str] = None,
     # These are protected fields, internal secret must match
     github_event_type: typing.Optional[str] = None,
     github_check_run_id: typing.Optional[int] = None,
@@ -357,10 +358,11 @@ def post_advise_python(
     parameters = locals()
     parameters["application_stack"] = parameters["input"].pop("application_stack")
 
-    if Configuration.INTERNAL_SECRET == internal_secret:
+    if Configuration.API_TOKEN == token:
         for k in protected_fields:
             if parameters[k] is not None:
-                raise PermissionError("Attempted to set protected field without proper permissions.")
+                response = {"error": "Attempted to set protected field without proper permissions."}
+                return response, 401
 
     # Always try to parse runtime environment so that we have it available in JSON reports in a unified form.
     try:

--- a/thoth/user_api/configuration.py
+++ b/thoth/user_api/configuration.py
@@ -34,6 +34,7 @@ class Configuration:
     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
     THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
     THOTH_HOST = os.environ["THOTH_HOST"]
+    INTERNAL_SECRET = os.getenv("THOTH_INTERNAL_API_SECRET", "secret101")
     # Give cache 3 hours by default.
     THOTH_CACHE_EXPIRATION = int(os.getenv("THOTH_CACHE_EXPIRATION", timedelta(hours=3).total_seconds()))
 

--- a/thoth/user_api/configuration.py
+++ b/thoth/user_api/configuration.py
@@ -34,7 +34,7 @@ class Configuration:
     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
     THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
     THOTH_HOST = os.environ["THOTH_HOST"]
-    INTERNAL_SECRET = os.getenv("THOTH_INTERNAL_API_SECRET", "secret101")
+    API_TOKEN = os.getenv("THOTH_USER_API_TOKEN")
     # Give cache 3 hours by default.
     THOTH_CACHE_EXPIRATION = int(os.getenv("THOTH_CACHE_EXPIRATION", timedelta(hours=3).total_seconds()))
 


### PR DESCRIPTION
## Related Issues and Dependencies



## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Some fields should not be trusted to be set by users but still need to be passed through the user-api.  Added a secret which can be set by internal components