### PR TITLE
Remove check on force from after_request

### DIFF
--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -239,7 +239,7 @@ def expose_cache_hit_metrics(response):
             return response
 
         if data["analysis_id"].startswith("adviser-"):
-            if data["cached"] and not data["parameters"]["force"]:
+            if data["cached"]:
                 try:
                     if data["authenticated"]:
                         metrics_values.update_adviser_cache_hit_metric(is_auth=True)
@@ -250,7 +250,7 @@ def expose_cache_hit_metrics(response):
                 except Exception as metric_exc:
                     _LOGGER.error("Failed to set metric for adviser cache hits: %r", metric_exc)
         elif data["analysis_id"].startswith("provenance-checker-"):
-            if data["cached"] and not data["parameters"]["force"]:
+            if data["cached"]:
                 try:
                     if data["authenticated"]:
                         metrics_values.update_provenance_checker_cache_hit_metric(is_auth=True)


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
        "Traceback (most recent call last):\n",
        "  File \"/opt/app-root/lib64/python3.8/site-packages/flask/app.py\", line 2447, in wsgi_app\n    response = self.full_dispatch_request()\n",
        "  File \"/opt/app-root/lib64/python3.8/site-packages/flask/app.py\", line 1953, in full_dispatch_request\n    return self.finalize_request(rv)\n",
        "  File \"/opt/app-root/lib64/python3.8/site-packages/flask/app.py\", line 1970, in finalize_request\n    response = self.process_response(response)\n",
        "  File \"/opt/app-root/lib64/python3.8/site-packages/flask/app.py\", line 2267, in process_response\n    response = handler(response)\n",
        "  File \"/opt/app-root/src/thoth/user_api/openapi_server.py\", line 242, in expose_cache_hit_metrics\n    if data[\"cached\"] and not data[\"parameters\"][\"force\"]:\n",
        "KeyError: 'force'\n"
```

Force is removed from parameters, therefore is not available after the request. 