### PR TITLE
initialize producer in similar way to database

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -90,9 +90,6 @@ _ADVISE_PROTECTED_FIELDS = frozenset(
 _PROVENANCE_CHECK_PROTECTED_FIELDS = frozenset({"kebechet_metadata"})
 
 
-p = producer.create_producer()
-
-
 def _compute_digest_params(parameters: dict):
     """Compute digest on parameters passed."""
     return hashlib.sha256(json.dumps(parameters, sort_keys=True).encode()).hexdigest()
@@ -1095,11 +1092,12 @@ def _send_schedule_message(
     with_authentication: bool = False,
     authenticated: bool = False,
 ):
+    from .openapi_server import PRODUCER
+
     message_contents["service_version"] = SERVICE_VERSION
     message_contents["component_name"] = COMPONENT_NAME
     message = content(**message_contents)
-    producer.publish_to_topic(p, message_type, message)
-    p.flush()
+    producer.publish_to_topic(PRODUCER, message_type, message)
     if "job_id" in message_contents:
 
         if with_authentication:

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -40,6 +40,7 @@ from thoth.common import init_logging
 from thoth.storages import __version__ as __storages__version__
 from thoth.python import __version__ as __python__version__
 from thoth.messaging import __version__ as __messaging__version__
+import thoth.messaging.producer as producer
 from thoth.storages import GraphDatabase
 from thoth.storages.exceptions import DatabaseNotInitialized
 from thoth.user_api import __version__
@@ -146,6 +147,9 @@ class _GraphDatabaseWrapper:
 # reuse connection pooling from one instance. Any call to this wrapper has to be done after the wsgi fork
 # (hence the wrapper logic).
 GRAPH = _GraphDatabaseWrapper()
+
+# similarly to DB we create one confluent-kafka-python producer
+PRODUCER = producer.create_producer()
 
 # custom metric to expose head revision from thoth-storages library
 schema_revision_metric = metrics.info(


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/user-api/pull/1455
#1458 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

producers were being killed after each request which is why #1455 was required. This fix should make it so that producers live forever and buffer timeout should be reached removing the need for manually flushing.