### PR TITLE
Make pre-commit happy

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -67,8 +67,8 @@ from .image import get_image_metadata
 from .exceptions import ImageError
 from .exceptions import ImageBadRequestError
 from .exceptions import ImageManifestUnknownError
-from .exceptions import ImageAuthenticationRequired
-from .exceptions import ImageInvalidCredentials
+from .exceptions import ImageAuthenticationRequiredError
+from .exceptions import ImageInvalidCredentialsError
 from . import __version__ as SERVICE_VERSION  # noqa
 from . import __name__ as COMPONENT_NAME  # noqa
 
@@ -1127,13 +1127,13 @@ def _do_get_image_metadata(
     except ImageBadRequestError as exc:
         status_code = 400
         error_str = str(exc)
-    except ImageInvalidCredentials as exc:
+    except ImageInvalidCredentialsError as exc:
         status_code = 403
         error_str = str(exc)
     except ImageManifestUnknownError as exc:
         status_code = 400
         error_str = str(exc)
-    except ImageAuthenticationRequired as exc:
+    except ImageAuthenticationRequiredError as exc:
         status_code = 401
         error_str = str(exc)
     except ImageError as exc:

--- a/thoth/user_api/exceptions.py
+++ b/thoth/user_api/exceptions.py
@@ -18,15 +18,15 @@
 """Exceptions raised in the whole user-api implementation."""
 
 
-class UserApiException(Exception):
+class UserApiExceptionError(Exception):
     """A base class for user API exceptions."""
 
 
-class NotFoundException(UserApiException):
+class NotFoundExceptionnError(UserApiExceptionError):
     """An exception raised if the requested resource could not be found."""
 
 
-class ImageError(UserApiException):
+class ImageError(UserApiExceptionError):
     """An exception raised if inspection of the given image was not successful."""
 
 
@@ -38,9 +38,9 @@ class ImageManifestUnknownError(ImageError):
     """An exception raised if manifest of the given image is not known."""
 
 
-class ImageAuthenticationRequired(ImageError):
+class ImageAuthenticationRequiredError(ImageError):
     """An exception raised if there is a need to authenticate against registry to inspect the given image."""
 
 
-class ImageInvalidCredentials(ImageError):
+class ImageInvalidCredentialsError(ImageError):
     """An exception raised if the given username/password provided to access the image is invalid."""

--- a/thoth/user_api/image.py
+++ b/thoth/user_api/image.py
@@ -22,11 +22,11 @@ import shlex
 
 from thoth.analyzer import run_command
 
-from .exceptions import ImageInvalidCredentials
+from .exceptions import ImageInvalidCredentialsError
 from .exceptions import ImageError
 from .exceptions import ImageBadRequestError
 from .exceptions import ImageManifestUnknownError
-from .exceptions import ImageAuthenticationRequired
+from .exceptions import ImageAuthenticationRequiredError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,13 +76,15 @@ def get_image_metadata(
     if "manifest unknown" in result.stderr:
         raise ImageManifestUnknownError("Unknown manifest for the given image")
     elif "unauthorized: authentication required" in result.stderr:
-        raise ImageAuthenticationRequired("There is required authentication in order to pull image and image details")
+        raise ImageAuthenticationRequiredError(
+            "There is required authentication in order to pull image and image details"
+        )
     elif "x509: certificate signed by unknown authority" in result.stderr:
-        raise ImageAuthenticationRequired(
+        raise ImageAuthenticationRequiredError(
             "There was an error with x509 certification check: certificate signed by unknown authority"
         )
     elif "unable to retrieve auth token: invalid username/password" in result.stderr:
-        raise ImageInvalidCredentials(
+        raise ImageInvalidCredentialsError(
             "There was an error accessing the image as the username/password provided was invalid"
         )
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

```

thoth/user_api/exceptions.py:21:8: N818 exception name 'UserApiException' should be named with an Error suffix
thoth/user_api/exceptions.py:25:8: N818 exception name 'NotFoundException' should be named with an Error suffix
thoth/user_api/exceptions.py:41:8: N818 exception name 'ImageAuthenticationRequired' should be named with an Error suffix
thoth/user_api/exceptions.py:45:8: N818 exception name 'ImageInvalidCredentials' should be named with an Error suffix

```