### PR TITLE
Expose cache expiration configuration

### DIFF
--- a/thoth/user_api/configuration.py
+++ b/thoth/user_api/configuration.py
@@ -32,7 +32,6 @@ class Configuration:
     SKOPEO_BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "bin", "skopeo")
     THOTH_MIDDLETIER_NAMESPACE = os.environ["THOTH_MIDDLETIER_NAMESPACE"]
     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
-    THOTH_FRONTEND_NAMESPACE = os.environ["THOTH_FRONTEND_NAMESPACE"]
     THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
     THOTH_HOST = os.environ["THOTH_HOST"]
     API_TOKEN = os.getenv("THOTH_USER_API_TOKEN")

--- a/thoth/user_api/configuration.py
+++ b/thoth/user_api/configuration.py
@@ -32,6 +32,7 @@ class Configuration:
     SKOPEO_BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "bin", "skopeo")
     THOTH_MIDDLETIER_NAMESPACE = os.environ["THOTH_MIDDLETIER_NAMESPACE"]
     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
+    THOTH_FRONTEND_NAMESPACE = os.environ["THOTH_FRONTEND_NAMESPACE"]
     THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
     THOTH_HOST = os.environ["THOTH_HOST"]
     API_TOKEN = os.getenv("THOTH_USER_API_TOKEN")

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -37,6 +37,7 @@ from flask_cors import CORS
 from thoth.common import __version__ as __common__version__
 from thoth.common import datetime2datetime_str
 from thoth.common import init_logging
+from thoth.common import Openshift
 from thoth.storages import __version__ as __storages__version__
 from thoth.python import __version__ as __python__version__
 from thoth.messaging import __version__ as __messaging__version__
@@ -156,11 +157,21 @@ schema_revision_metric = metrics.info(
     env=Configuration.THOTH_DEPLOYMENT_NAME,
 )
 
+# custom metric to expose cache expiration configuration
+user_api_cache_expiration_configuration = metrics.info(
+    "user_api_cache_expiration_configuration",
+    "Thoth User API cache exporation configuration",
+    component="user-api",  # label
+    env=Configuration.THOTH_DEPLOYMENT_NAME,
+)
 
 @application.before_first_request
 def before_first_request_callback():
     """Register callback, runs before first request to this service."""
     schema_revision_metric.set(1)
+    openshift = Openshift()
+    cache_expiration_time = openshift.get_cache_expiration_configuration()  #[s]
+    user_api_cache_expiration_configuration.set(cache_expiration_time)
     _LOGGER.info("Running once before first request to expose metric.")
 
 

--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -37,7 +37,6 @@ from flask_cors import CORS
 from thoth.common import __version__ as __common__version__
 from thoth.common import datetime2datetime_str
 from thoth.common import init_logging
-from thoth.common import Openshift
 from thoth.storages import __version__ as __storages__version__
 from thoth.python import __version__ as __python__version__
 from thoth.messaging import __version__ as __messaging__version__
@@ -161,17 +160,15 @@ schema_revision_metric = metrics.info(
 user_api_cache_expiration_configuration = metrics.info(
     "user_api_cache_expiration_configuration",
     "Thoth User API cache exporation configuration",
-    component="user-api",  # label
     env=Configuration.THOTH_DEPLOYMENT_NAME,
 )
+
 
 @application.before_first_request
 def before_first_request_callback():
     """Register callback, runs before first request to this service."""
     schema_revision_metric.set(1)
-    openshift = Openshift()
-    cache_expiration_time = openshift.get_cache_expiration_configuration()  #[s]
-    user_api_cache_expiration_configuration.set(cache_expiration_time)
+    user_api_cache_expiration_configuration.set(Configuration.THOTH_CACHE_EXPIRATION)  # [s]
     _LOGGER.info("Running once before first request to expose metric.")
 
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/metrics-exporter/issues/615

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Expose cache expiration configuration on user-api metrics.
