### PR TITLE
Drop /s2i/python endpoint and promote container images endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -526,28 +526,15 @@ paths:
     get:
       tags: [Container Images]
       x-openapi-router-controller: thoth.user_api.api_v1
-      operationId: list_container_images
-      summary: Get analyzed container images.
+      operationId: list_thoth_container_images
+      summary: List available Thoth container images.
       responses:
         "200":
-          description: A list of analyzed container images.
+          description: A list of available Thoth container images.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContainerImagesResponse"
-  /s2i/python:
-    get:
-      tags: [s2i]
-      x-openapi-router-controller: thoth.user_api.api_v1
-      operationId: list_s2i_python
-      summary: Get available S2I base container images for Python applications.
-      responses:
-        "200":
-          description: A list of available Python S2I.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/S2IPythonResponse"
 
   /advise/python/{analysis_id}/log:
     get:
@@ -1748,8 +1735,8 @@ components:
               - image_sha
               - os_name
               - os_version
-              - thoth_s2i_image_name
-              - thoth_s2i_image_version
+              - thoth_image_name
+              - thoth_image_version
               - cuda_version
               - environment_type
             properties:
@@ -1774,11 +1761,11 @@ components:
               os_version:
                 type: string
                 example: '8'
-              thoth_s2i_image_name:
+              thoth_image_name:
                 type: string
                 example: 'quay.io/thoth-station/s2i-thoth-ubi8-py38'
                 nullable: true
-              thoth_s2i_image_version:
+              thoth_image_version:
                 type: string
                 example: 'v1.0.0'
               cuda_version:
@@ -1800,42 +1787,6 @@ components:
               type: integer
               example: 0
               description: Page offset in the pagination.
-
-    S2IPythonResponse:
-      type: object
-      required:
-        - s2i
-      properties:
-        s2i:
-          type: array
-          items:
-            type: object
-            required:
-              - thoth_s2i
-              - thoth_s2i_image_name
-              - thoth_s2i_image_version
-              - analysis_id
-            properties:
-              thoth_s2i:
-                type: string
-                description: Full qualifier of Thoth's s2i.
-                nullable: false
-                example: quay.io/thoth-station/s2i-thoth-ubi8-py38:v1.0.0
-              thoth_s2i_image_name:
-                type: string
-                description: Name of the Thoth s2i.
-                nullable: false
-                example: quay.io/thoth-station/s2i-thoth-ubi8-py38
-              thoth_s2i_image_version:
-                type: string
-                description: Version of the Thoth s2i.
-                nullable: false
-                example: "1.0.0"
-              analysis_id:
-                type: string
-                description: Container image analysis id.
-                nullable: false
-                example: package-extract-foo
 
     AnalysisLogResponse:
       type: object

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -181,44 +181,15 @@ def get_analyze(analysis_id: str):
     )
 
 
-def list_s2i_python() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
-    """List all available Python s2i."""
-    from .openapi_server import GRAPH
-
-    entries = []
-    for thoth_s2i_image_name, thoth_s2i_image_version in GRAPH.get_thoth_s2i_all(is_external=False):
-        analyses = GRAPH.get_thoth_s2i_package_extract_analysis_document_id_all(
-            thoth_s2i_image_name, thoth_s2i_image_version, is_external=False
-        )
-
-        if not analyses:
-            _LOGGER.error(
-                "Thoth s2i image %r in version %r was not analyzed, please schedule container image "
-                "analyses to make it available to users",
-                thoth_s2i_image_name,
-                thoth_s2i_image_version,
-            )
-            continue
-
-        entries.append(
-            {
-                "thoth_s2i_image_name": thoth_s2i_image_name,
-                "thoth_s2i_image_version": thoth_s2i_image_version,
-                "thoth_s2i": f"{thoth_s2i_image_name}:v{thoth_s2i_image_version}",
-                "analysis_id": analyses[-1],  # Show only the last, the most recent, one.
-            }
-        )
-
-    return {"s2i": entries}
-
-
-def list_container_images(page: int = 0) -> typing.Dict[str, typing.Any]:
-    """List registered container images."""
+def list_thoth_container_images(page: int = 0) -> typing.Dict[str, typing.Any]:
+    """List registered Thoth container images."""
     from .openapi_server import GRAPH
 
     entries = []
     for item in GRAPH.get_software_environments_all(is_external=False, start_offset=page):
         if item.get("env_image_name") and item.get("env_image_tag"):
+            item["thoth_image_name"] = item.pop("thoth_s2i_image_name", None)
+            item["thoth_image_version"] = item.pop("thoth_s2i_image_version", None)
             entries.append(item)
 
     return {"container_images": entries, "parameters": {"page": page}}


### PR DESCRIPTION
## This introduces a breaking change

- [x] Yes

## Description

As we provide multiple types of container images, it might be a good idea to drop s2i endpoint and promote generic contaienr images endpoint to serve information about containerized environments (ex. predictable stacks, s2i, ...).
