### PR TITLE
Fix return type for listing environments

### DIFF
--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -1124,10 +1124,10 @@ def get_package_from_imported_packages(import_name: str):
         )
 
 
-def list_python_environments() -> typing.List[typing.Dict[str, str]]:
+def list_python_environments() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
     """Get environments available based on solvers installed."""
     result = []
     for solver in _OPENSHIFT.get_solver_names():
         result.append(_OPENSHIFT.parse_python_solver_name(solver))
 
-    return result
+    return {"environment": result}


### PR DESCRIPTION
## Description

Fixes:

```
[{'os_name': 'rhel', 'os_version': '8', 'python_version': '3.6'}] is not of type 'object'
```

https://github.com/thoth-station/user-api/blob/76bd326cc4881791fa87d606a8f3d01dd76ecd63/openapi/openapi.yaml#L2060-L2068