### PR TITLE
Fix a bug in openapi schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1952,7 +1952,7 @@ components:
       required:
         - environments
       properties:
-        versions:
+        environments:
           type: array
           items:
             type: object


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

```
connexion.exceptions.InvalidSpecification: Required list has not defined properties: ['environments']
```
