### PR TITLE
Environment is not mandatory when querying Python package versions

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -955,19 +955,19 @@ paths:
             default: 0
         - name: os_name
           in: query
-          required: true
+          required: false
           description: Name of operating system to consider.
           schema:
             type: string
         - name: os_version
           in: query
-          required: true
+          required: false
           description: Version of operating system to consider.
           schema:
             type: string
         - name: python_version
           in: query
-          required: true
+          required: false
           description: Version of Python interpreter.
           schema:
             type: string


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
