### PR TITLE
Some of the items in /container-images response can be nullable

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1958,18 +1958,23 @@ components:
                 example: '3.8'
               env_image_name:
                 type: string
+                nullable: true
                 example: 's2i-minimal-notebook'
               env_image_tag:
                 type: string
+                nullable: true
                 example: 'v1.2.3'
               image_sha:
                 type: string
+                nullable: true
               os_name:
                 type: string
                 example: 'rhel'
+                nullable: true
               os_version:
                 type: string
                 example: '8'
+                nullable: true
               thoth_image_name:
                 type: string
                 example: 'quay.io/thoth-station/s2i-thoth-ubi8-py38'
@@ -1977,6 +1982,7 @@ components:
               thoth_image_version:
                 type: string
                 example: 'v1.0.0'
+                nullable: true
               cuda_version:
                 type: string
                 nullable: true


### PR DESCRIPTION
## Related Issues and Dependencies

```json
{
  "detail": "None is not of type 'string'\n\nFailed validating 'type' in schema['properties']['container_images']['items']['properties']['env_image_name']:\n    {'example': 's2i-minimal-notebook', 'type': 'string'}\n\nOn instance['container_images'][0]['env_image_name']:\n    None",
  "status": 500,
  "title": "Response body does not conform to specification",
  "type": "about:blank"
}
```

## This introduces a breaking change

- [x] No

