### PR TITLE
Rename import to package_import as it causes issues on client

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2277,7 +2277,7 @@ components:
               - package_name
               - package_version
               - index_url
-              - import
+              - package_import
             properties:
               package_name:
                 type: string
@@ -2294,7 +2294,7 @@ components:
                 nullable: false
                 description: Source index URL of the package.
                 example: "https://pypi.org/simple"
-              import:
+              package_import:
                 type: string
                 nullable: false
                 description: A module import matching the given criteria.

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -1364,10 +1364,14 @@ def get_package_from_imported_packages(import_name: str) -> Tuple[Dict[str, Any]
     from .openapi_server import GRAPH
 
     try:
+        result = GRAPH.get_python_package_version_import_packages_all(import_name=import_name, distinct=True)
+
+        # Remap "import" to "package_import" as it causes troubles when generating client.
+        for item in result:
+            item["package_import"] = item.pop("import")
+
         return {
-            "package_names": GRAPH.get_python_package_version_import_packages_all(
-                import_name=import_name, distinct=True
-            ),
+            "package_names": result,
             "parameters": parameters,
         }, 200
     except NotFoundError:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

When generating client, the `import` is renamed to `_import` as import is a keyword in Python. This than couses troubles when reporting imports to users. Let's rename this.
