### PR TITLE
Expose access control headers

### DIFF
--- a/thoth/user_api/openapi_server.py
+++ b/thoth/user_api/openapi_server.py
@@ -330,6 +330,9 @@ def apply_headers(response):
     """Add headers to each response."""
     response.headers["X-Thoth-Version"] = __version__
     response.headers["X-User-API-Service-Version"] = __service_version__
+    if "page" in response.headers:
+        # Expose headers to users.
+        response.headers["Access-Control-Expose-Headers"] = "page,entries_count,next,page_count,per_page,prev"
     return response
 
 


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/user-api/issues/1601

## This introduces a breaking change

- [x] No

## Description

Expose headers so consumers can access them.
