### PR TITLE
openapi parameter schema default value doesnt take null

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1474,7 +1474,7 @@ components:
       schema:
         type: boolean
         nullable: true
-        default: null
+        default: false
     import_name:
       name: import_name
       in: query


### PR DESCRIPTION
openapi parameter schema default value doesn't take null
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/user-api/issues/1636

