### PR TITLE
Fix `advised_manifest_changes` type in OpenAPI schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2921,7 +2921,7 @@ components:
                         nullable: true
                         description: Advised changes to manifest files
                         items:
-                          type: object
+                          type: array
                           description: A change that was advised
                       advised_runtime_environment:
                         nullable: true


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Fix type error in OpenAPI schema which causes `thamos_advise` integration tests scenario to fail in stage with the following error:

```
raise ApiError(
      thamos.exceptions.ApiError: Thoth Backend didn't respond with correct status code. Returned code - 500: {
        "detail": "[{'apiVersion': 'apps.openshift.io/v1', 'kind': 'DeploymentConfig', 'patch': {'op': 'add', 'path': '/spec/template/spec/containers/0/env/0', 'value': {'name': 'TF_ENABLE_ONEDNN_OPTS', 'value': '1'}}}] is not of type 'object'\n\nFailed validating 'type' in schema['properties']['result']['properties']['report']['properties']['products']['items']['properties']['advised_manifest_changes']['items']:\n    {'description': 'A change that was advised', 'type': 'object'}\n\nOn instance['result']['report']['products'][0]['advised_manifest_changes'][0]:\n    [{'apiVersion': 'apps.openshift.io/v1',\n      'kind': 'DeploymentConfig',\n      'patch': {'op': 'add',\n                'path': '/spec/template/spec/containers/0/env/0',\n                'value': {'name': 'TF_ENABLE_ONEDNN_OPTS', 'value': '1'}}}]",
        "status": 500,
        "title": "Response body does not conform to specification",
        "type": "about:blank"
      }
```
