### PR TITLE
Downgrade connexion ==2.3.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 attrs = "*"
-connexion = {extras = ["swagger-ui"],version = "*"}
+connexion = {version = "==2.3.0", extras = ["swagger-ui"]}
 flask = "<=1.0.0"
 flask-script = "*"
 grpcio = "<1.28"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c850be40236e31c80e09c406eed1254fb8ab929a8c5ca05f17e63c75e3ae7319"
+            "sha256": "d6a8baba9c59a05163bf1e7684f5f975d9110595aec9e5d7e7eb00249b22df73"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Related Issues and Dependencies

Related to #1708 

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Downgrade `connexion` to version `2.3.0` to fix the `ImportError` from `werkzeug`.
Dependencies were updated using pipenv.