### PR TITLE
Fix initialize_repo operationId in schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -807,7 +807,7 @@ paths:
     post:
       tags: [Kebechet]
       x-openapi-router-controller: thoth.user_api.api_v1
-      operationId: thoth_initialize_repo
+      operationId: initialize_repo
       summary: Initialize the user's provided repository.
       requestBody:
         required: true


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Fix [`thoth_initialize_repo`](https://github.com/thoth-station/user-api/blob/e34bf3c0f36f1f151950fe6c43e60c503551df3a/openapi/openapi.yaml#L810) `operationId` in the openAPI schema to `initialize_repo` to correspond to the implementation of this operation in `api_v1.py`: 

https://github.com/thoth-station/user-api/blob/e34bf3c0f36f1f151950fe6c43e60c503551df3a/thoth/user_api/api_v1.py#L1137



