### PR TITLE
Remove limit and count from the advise endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -514,8 +514,6 @@ paths:
               $ref: "#/components/schemas/AdviseInput"
       parameters:
       - $ref: "#/components/parameters/recommendation_type"
-      - $ref: "#/components/parameters/count"
-      - $ref: "#/components/parameters/limit"
       - $ref: "#/components/parameters/origin_py"
       - $ref: "#/components/parameters/source_type"
       - $ref: "#/components/parameters/dev"
@@ -1312,20 +1310,6 @@ components:
         - performance
         - security
         default: latest
-    count:
-      name: count
-      in: query
-      description: Number of software stacks that should be returned
-      schema:
-        type: integer
-      required: false
-    limit:
-      name: limit
-      in: query
-      description: Limit number of software stacks scored
-      schema:
-        type: integer
-      required: false
     source_type:
       name: source_type
       in: query

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -466,8 +466,6 @@ def get_provenance_python_status(analysis_id: str) -> Tuple[Dict[str, Any], int]
 def post_advise_python(
     input: Dict[str, Any],
     recommendation_type: Optional[str] = None,
-    count: Optional[int] = None,
-    limit: Optional[int] = None,
     source_type: Optional[str] = None,
     debug: bool = False,
     force: bool = False,
@@ -541,8 +539,6 @@ def post_advise_python(
         cached_document_id = _compute_digest_params(
             dict(
                 **project.to_dict(),
-                count=parameters["count"],
-                limit=parameters["limit"],
                 library_usage=parameters["library_usage"],
                 recommendation_type=recommendation_type,
                 origin=origin,
@@ -557,8 +553,6 @@ def post_advise_python(
         cached_document_id = _compute_digest_params(
             dict(
                 **project.to_dict(),
-                count=parameters["count"],
-                limit=parameters["limit"],
                 library_usage=parameters["library_usage"],
                 recommendation_type=recommendation_type,
                 dev=dev,


### PR DESCRIPTION
## Related Issues and Dependencies

Closes: 1726

## This introduces a breaking change

- Yes, partially

## This should yield a new module release

- No

## Description

Remove unused count and limit parameters. They are propagated from the templates so we should be safe to do so.

