### PR TITLE
Revert to `click==8.0.4` in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     rev: 21.6b0
     hooks:
       - id: black
+        additional_dependencies: ['click==8.0.4']
 
   - repo: https://github.com/tomcatling/black-nb
     rev: "0.5.0"


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #1734 

## This introduces a breaking change

- No

## This should yield a new module release

- No

## This Pull Request implements

Revert to an earlier version of `click` in pre-commit config to avoid error related to `_unicodefun` import in `black`.
