### PR TITLE
Fix default marker_evaluation_result value in package dependencies endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1520,7 +1520,7 @@ components:
       schema:
         type: boolean
         nullable: true
-        default: false
+        default: null
     import_name:
       name: import_name
       in: query


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

The `marker_evaluation_result` default value in the `/python/package/dependencies` endpoint should be set to `null` instead of `false`. Otherwise, this causes the following error:

```
"error": "Operating system and Python interpreter version need to be specified to obtain dependencies dependent on marker evaluation result"
```
for any value of `marker_evaluation_result`.

