### PR TITLE
added option for starts_with filter on /python/package

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1207,13 +1207,13 @@ components:
         - ASC
         - DESC
     starts_with:
-      name: starts_with
+      name: like
       in: query
       required: false
-      description: Filter Python package name by starting string
+      description: Filter Python package name by string. (wildcard characters "%" and "_" are supported)
       schema:
         type: string
-        example: pandas
+        example: pa%
     page:
       name: page
       in: query

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -994,6 +994,7 @@ paths:
       - $ref: "#/components/parameters/os_name"
       - $ref: "#/components/parameters/os_version"
       - $ref: "#/components/parameters/python_version"
+      - $ref: "#/components/parameters/starts_with"
       responses:
         "200":
           description: Listing of available Python packages
@@ -1205,6 +1206,14 @@ components:
         enum:
         - ASC
         - DESC
+    starts_with:
+      name: starts_with
+      in: query
+      required: false
+      description: Filter Python package name by starting string
+      schema:
+        type: string
+        example: pandas
     page:
       name: page
       in: query

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -669,7 +669,7 @@ def list_python_packages(
     os_name: Optional[str] = None,
     os_version: Optional[str] = None,
     python_version: Optional[str] = None,
-    starts_with: Optional[str] = None
+    like: Optional[str] = None
 ) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     """Get listing of solved package names."""
     per_page = min(per_page, PAGINATION_SIZE_MAX)
@@ -682,7 +682,7 @@ def list_python_packages(
         os_version=os_version,
         python_version=python_version,
         distinct=True,
-        starts_with=starts_with,
+        like=like,
     )
 
     page_count = ceil(entries_count / per_page)
@@ -696,7 +696,7 @@ def list_python_packages(
         os_name=os_name,
         os_version=os_version,
         python_version=python_version,
-        starts_with=starts_with,
+        like=like,
     )
 
     prev_page, next_page = _compute_prev_next_page(page, page_count)

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -669,6 +669,7 @@ def list_python_packages(
     os_name: Optional[str] = None,
     os_version: Optional[str] = None,
     python_version: Optional[str] = None,
+    starts_with: Optional[str] = None
 ) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     """Get listing of solved package names."""
     per_page = min(per_page, PAGINATION_SIZE_MAX)
@@ -681,6 +682,7 @@ def list_python_packages(
         os_version=os_version,
         python_version=python_version,
         distinct=True,
+        starts_with=starts_with,
     )
 
     page_count = ceil(entries_count / per_page)
@@ -694,6 +696,7 @@ def list_python_packages(
         os_name=os_name,
         os_version=os_version,
         python_version=python_version,
+        starts_with=starts_with,
     )
 
     prev_page, next_page = _compute_prev_next_page(page, page_count)

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -669,7 +669,7 @@ def list_python_packages(
     os_name: Optional[str] = None,
     os_version: Optional[str] = None,
     python_version: Optional[str] = None,
-    like: Optional[str] = None
+    like: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     """Get listing of solved package names."""
     per_page = min(per_page, PAGINATION_SIZE_MAX)


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/user-api/issues/1743

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Added a new optional parameter to the `/python/package` endpoint called `start_with`.
## Description

`starts_with` will filter the query to only include packages that have a name that starts with `starts_with` input value 
<!--- Describe your changes in detail -->
