### PR TITLE
Pinned down werkzeug 2.0.3 version to get sentry warning fixed

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,24 +4,25 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+aiocontextvars = "*"
 attrs = "*"
+confluent-kafka = "*"
 connexion = {extras = ["swagger-ui"],version = "*"}
-flask = "*"
+flask = "<=2.1.3"
+flask-cors = "*"
 grpcio = "<1.28"
 grpcio-tools = "<1.28"
 gunicorn = "*"
+openapi-schema-validator = "<0.2.0"
 prometheus-flask-exporter = "*"
 requests = "*"
+sentry-sdk = {extras = ["flask"],version = "*"}
 thoth-analyzer = "*"
 thoth-common = "*"
+thoth-messaging = "*"
 thoth-python = "*"
 thoth-storages = "*"
-flask-cors = "*"
-openapi-schema-validator = "<0.2.0"
-aiocontextvars = "*"
-sentry-sdk = {extras = ["flask"],version = "*"}
-confluent-kafka = "*"
-thoth-messaging = "*"
+werkzeug = "<=2.0.3"
 
 [pipenv]
 allow_prereleases = false

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fd18cc7cf48976ca8ac6b39721e4293f45ef3ddd967ed8d8037c516b9872bebe"
+            "sha256": "fe03aa41cd44a9bdbe9d7f253d4b2378f0054e558920d0c95e3e8bbb674c8a47"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -174,7 +174,7 @@
                 "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
                 "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
             ],
-            "markers": "python_version >= '3.6' and python_version < '3.9'",
+            "markers": "python_version < '3.9' and python_version >= '3.6' and python_version < '3.9'",
             "version": "==0.2.1"
         },
         "beautifulsoup4": {
@@ -194,19 +194,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:09fb94008bd1f2566ef79ec7d8dd7a233b5da67f3b2536e30432eb8e88022d4d",
-                "sha256:9fab8acec76008797be4671d514f39f1163ba044c0a0bce8d5afe8b52cbd5550"
+                "sha256:1be1aa320ef33d6e10e82adea3caeb0d2c185284457d1e2406339b44f45d7565",
+                "sha256:74a50c718594a38fa846ce6951ea4704a5836194e2d4055e959baef39299d283"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.24.56"
+            "version": "==1.24.57"
         },
         "botocore": {
             "hashes": [
-                "sha256:81101abab2013992a84019739d85a6fa8ec6f1f42fb09ad07e0bf4c8f0efce60",
-                "sha256:81df81b1a1c5608b3a7aca6a837acb27552c3ecc92584a58b171c60754b1d4eb"
+                "sha256:e55510321dba95065a071909177ab6d4e1621b41f090cefe54252af9b0766855",
+                "sha256:f3dd75a789ac1a3e3f06fe0725ee138522c106c4e6abc917a4915617c4a32662"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.56"
+            "version": "==1.27.57"
         },
         "cachetools": {
             "hashes": [
@@ -388,11 +388,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b",
-                "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"
+                "sha256:15972e5017df0575c3d6c090ba168b6db90259e620ac8d7ea813a396bad5b6cb",
+                "sha256:9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==2.1.3"
         },
         "flask-cors": {
             "hashes": [
@@ -594,7 +594,7 @@
                 "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
                 "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version < '3.10' and python_version < '3.9'",
             "version": "==4.12.0"
         },
         "importlib-resources": {
@@ -602,7 +602,7 @@
                 "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681",
                 "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"
             ],
-            "markers": "python_version < '3.9'",
+            "markers": "python_version < '3.9' and python_version < '3.9'",
             "version": "==5.9.0"
         },
         "inflection": {
@@ -1151,7 +1151,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "python-json-logger": {
@@ -1296,7 +1296,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "python_version < '3.11' and platform_python_implementation == 'CPython'",
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.11'",
             "version": "==0.2.6"
         },
         "s3transfer": {
@@ -1331,7 +1331,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "sqlalchemy": {
@@ -1444,7 +1444,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "typing-extensions": {
@@ -1473,11 +1473,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
-                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.26.11"
+            "version": "==1.26.12"
         },
         "voluptuous": {
             "hashes": [
@@ -1496,11 +1496,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f",
-                "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
+                "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
+                "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.2"
+            "index": "pypi",
+            "version": "==2.0.3"
         },
         "yarl": {
             "hashes": [


### PR DESCRIPTION
Pinned down werkzeug 2.0.3 version to get sentry warning fixed
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/user-api/issues/1769

## This introduces a breaking change

- Yes
- No

## Description

Trying out the solution: https://github.com/thoth-station/user-api/issues/1769#issuecomment-1217182031