### PR TITLE
[WIP] Add TTL of cached documents in response headers

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -902,6 +902,8 @@ paths:
               $ref: "#/components/headers/x-thoth-version"
             x-user-api-service-version:
               $ref: "#/components/headers/x-user-api-service-version"
+            x-thoth-cached-document-ttl:
+              $ref: "#/components/headers/x-thoth-cached-document-ttl"
           content:
             application/json:
               schema:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -77,6 +77,8 @@ paths:
               $ref: "#/components/headers/x-user-api-service-version"
             x-thoth-search-ui-url:
               $ref: "#/components/headers/x-thoth-search-ui-url"
+            x-thoth-cached-document-ttl:
+              $ref: "#/components/headers/x-thoth-cached-document-ttl"
           content:
             application/json:
               schema:
@@ -315,6 +317,8 @@ paths:
               $ref: "#/components/headers/x-thoth-version"
             x-user-api-service-version:
               $ref: "#/components/headers/x-user-api-service-version"
+            x-thoth-cached-document-ttl:
+              $ref: "#/components/headers/x-thoth-cached-document-ttl"
           content:
             application/json:
               schema:
@@ -530,6 +534,8 @@ paths:
               $ref: "#/components/headers/x-user-api-service-version"
             x-thoth-search-ui-url:
               $ref: "#/components/headers/x-thoth-search-ui-url"
+            x-thoth-cached-document-ttl:
+              $ref: "#/components/headers/x-thoth-cached-document-ttl"
           content:
             application/json:
               schema:
@@ -1577,6 +1583,11 @@ components:
       schema:
         type: string
         example: https://thoth-station.ninja/search/
+    x-thoth-cached-document-ttl:
+      description: Thoth cached document Time To Live
+      schema:
+        type: integer
+        example: 7200
     page:
       description: Current page
       schema:


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/user-api/issues/1614

## This introduces a breaking change

- Yes

## This should yield a new module release

- Yes

## This Pull Request implements

Add TTL for cached documents in HTTP response headers for the following endpoints:

- `/advise/python`
- `/analyze`
- `/build-analysis`
- `/provenance/python`

## Description

This PR is a work in progress: 

- [ ] Needs testing
- [x] Depends on https://github.com/thoth-station/storages/pull/2676
