### PR TITLE
Handle image invalid reference format in analyze endpoint

### DIFF
--- a/thoth/user_api/exceptions.py
+++ b/thoth/user_api/exceptions.py
@@ -44,3 +44,7 @@ class ImageAuthenticationRequiredError(ImageError):
 
 class ImageInvalidCredentialsError(ImageError):
     """An exception raised if the given username/password provided to access the image is invalid."""
+
+
+class ImageInvalidReferenceFormatError(ImageError):
+    """An exception raised if the given image reference could not be parsed by Skopeo."""

--- a/thoth/user_api/image.py
+++ b/thoth/user_api/image.py
@@ -27,6 +27,7 @@ from .exceptions import ImageError
 from .exceptions import ImageBadRequestError
 from .exceptions import ImageManifestUnknownError
 from .exceptions import ImageAuthenticationRequiredError
+from .exceptions import ImageInvalidReferenceFormatError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,6 +88,9 @@ def get_image_metadata(
         raise ImageInvalidCredentialsError(
             "There was an error accessing the image as the username/password provided was invalid"
         )
+
+    elif "invalid reference format" in result.stderr:
+        raise ImageInvalidReferenceFormatError("The image reference format specified is invalid.")
 
     _LOGGER.error("An unhandled error occurred during extraction of image %r: %s", image_name, result.stderr)
     raise ImageError(


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes Sentry issue THTH-001-THOTH-1T79

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Handle invalid container image reference format when posting an image analysis request.
