### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         additional_dependencies: ["types-requests"]
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         additional_dependencies: ['click==8.0.4']
@@ -60,8 +60,8 @@ repos:
   #   hooks:
   #     - id: check-manifest
 
-  - repo: https://gitlab.com/PyCQA/flake8
-    rev: "3.9.2"
+  - repo: https://github.com/PyCQA/flake8
+    rev: "5.0.4"
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]
@@ -70,7 +70,7 @@ repos:
           ["--ignore", "E2,W5", "--select", "E,W,F,N", "--max-line-length=120"]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.27.1
+    rev: v1.28.0
     hooks:
     - id: yamllint
       args: [-c=.yamllint]


### PR DESCRIPTION
## Related Issues and Dependencies

#1826 and #1827 are currently failing presubmit pre-commit job due to the current configuration that points to gitlab for flake8

## This introduces a breaking change

- No

## This should yield a new module release

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Update the pre-commit configuration to point to https://github.com/PyCQA/flake8 instead of https://gitlab.com/PyCQA/flake8.

Also update versions