### PR TITLE
removed 404 error on list query

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -611,17 +611,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContainerImagesResponseError"
-        "404":
-          description: No Thoth container images with the given Image found
-          headers:
-            x-thoth-version:
-              $ref: "#/components/headers/x-thoth-version"
-            x-user-api-service-version:
-              $ref: "#/components/headers/x-user-api-service-version"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ContainerImagesResponseError"
   /advise/python/{analysis_id}/log:
     get:
       tags: [Advise]

--- a/thoth/user_api/api_v1.py
+++ b/thoth/user_api/api_v1.py
@@ -384,9 +384,6 @@ def list_thoth_container_images(
 
     prev_page, next_page = _compute_prev_next_page(page, per_page)
 
-    if len(entries) == 0:
-        return ({"error": "No Image found", "parameters": parameters}, 404, {})
-
     return (
         {
             "container_images": entries,


### PR DESCRIPTION
## Related Issues and Dependencies
fixes https://github.com/thoth-station/thamos/issues/1184

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

removed 404 error for container images

## Description

I removed the 404 error from `/container-images` as it is best practice to return 200 on an empty query to a list of data. 404 would indicate that the actual resource does not exist. Resource can be interpreted as either the api endpoint or the table of container images. In both cases the response should still be 200 as the route completed successfully without error, just that there was notting to return. 

<!--- Describe your changes in detail -->
